### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_yml.yml
+++ b/.github/workflows/check_yml.yml
@@ -1,5 +1,8 @@
 name: Check YAML
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/zeolan/zeolan.github.io/security/code-scanning/1](https://github.com/zeolan/zeolan.github.io/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` field at the top level of the workflow file (immediately after `name:` and before `on:`). This will apply to all jobs in the workflow (unless a job-level override is set, which is not the case here). The minimal permissions needed for this job are `contents: read`, since the script only needs to check out and read files. Add the following lines to `.github/workflows/check_yml.yml`:

```yaml
permissions:
  contents: read
```

Insert this block after the `name:` key (line 1) and before `on:` (line 3).

No other methods, variable definitions, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
